### PR TITLE
Add shell script to execute CPP with input files

### DIFF
--- a/run_cpp.sh
+++ b/run_cpp.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Check if at least the filename argument is provided
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <filename.cpp> [input_file1.txt input_file2.txt ...]"
+    exit 1
+fi
+
+# Get the C++ file name
+FILENAME=$1
+BASENAME=$(basename "$FILENAME" .cpp)
+
+# Compile the C++ file
+g++ "$FILENAME" -o "$BASENAME"
+
+# Check if compilation was successful
+if [ $? -ne 0 ]; then
+    echo "Compilation failed."
+    exit 1
+fi
+
+# Check if any input files were provided
+if [ $# -gt 1 ]; then
+    # Loop through all input files provided as arguments
+    for INPUTFILE in "${@:2}"; do
+        if [ -f "$INPUTFILE" ]; then
+            OUTPUTFILE="${INPUTFILE%.txt}_output.txt"  # Create output file name
+            ./"$BASENAME" < "$INPUTFILE" > "$OUTPUTFILE"
+            echo "Execution completed for $INPUTFILE. Output written to $OUTPUTFILE."
+        else
+            echo "$INPUTFILE not found."
+        fi
+    done
+else
+    # No input files, just run the program
+    ./"$BASENAME"
+fi
+
+# Optionally delete the compiled executable
+rm "$BASENAME"
+
+echo "Executable deleted."


### PR DESCRIPTION
The shell script allows users to
execute a C++ file with zero or more input .txt files with the results are exported to output.txt file corresponding to the number of input files.

- How to use: ./run_cpp.sh <cpp file> [input file(s)]